### PR TITLE
swig fixes to handle unicode in py2

### DIFF
--- a/python/lsst/display/ds9/ds9.py
+++ b/python/lsst/display/ds9/ds9.py
@@ -184,7 +184,7 @@ def ds9Cmd(cmd=None, trap=True, flush=False, silent=True, frame=None, get=False)
         cmdBuffer._lenCommands += 1 + len(cmd)
 
     if flush or cmdBuffer._lenCommands >= cmdBuffer._getSize():
-        cmd = (cmdBuffer._commands + "\n").encode('utf-8')
+        cmd = (cmdBuffer._commands + "\n")
         cmdBuffer._commands = ""
         cmdBuffer._lenCommands = 0
     else:

--- a/python/lsst/display/ds9/xpa.i
+++ b/python/lsst/display/ds9/xpa.i
@@ -44,6 +44,10 @@ Simple interface to the xpa routines used to communicate with ds9
 %rename(set) XPASet1;
 %rename(setFd1) XPASetFd1;
 
+%begin %{
+    #define SWIG_PYTHON_2_UNICODE
+%}
+
 %{
 #include "xpa.h"
 #include "lsst/pex/exceptions/Runtime.h"

--- a/ups/display_ds9.table
+++ b/ups/display_ds9.table
@@ -1,4 +1,5 @@
 setupRequired(afw)
 setupRequired(xpa)
+setupRequired(python_future)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
- removed the .encode() from ds9.py
- added the SWIG_PYTHON_2_UNICODE directive to xpa.i
- added missing python_future from ups/display_ds9.table

Tested with afw/tests/testDisplay.py in py2 and py3 build trees