### PR TITLE
Tickets/dm 8874

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ _build.*
 config.log
 doc/*.tag
 doc/html
+doc/xml
 doc/doxygen.conf
 python/lsst/display/ds9/version.py
 python/lsst/display/ds9/xpa.py

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@ _build.*
 *.so
 *.os
 *.pyc
-*_wrap.cc
-*Lib.py
 .sconf_temp
 .sconsign.dblite
 config.log

--- a/python/lsst/display/ds9/SConscript
+++ b/python/lsst/display/ds9/SConscript
@@ -1,3 +1,3 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
-scripts.BasicSConscript.python(['xpa'])
+scripts.BasicSConscript.pybind11(['_xpa'])

--- a/python/lsst/display/ds9/__init__.py
+++ b/python/lsst/display/ds9/__init__.py
@@ -20,4 +20,5 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 from .version import *
+from .xpa import *
 from .ds9 import *

--- a/python/lsst/display/ds9/_xpa.cc
+++ b/python/lsst/display/ds9/_xpa.cc
@@ -1,0 +1,183 @@
+/*
+ * LSST Data Management System
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ * See the COPYRIGHT file
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <https://www.lsstcorp.org/LegalNotices/>.
+ */
+#include <pybind11/pybind11.h>
+
+#include "xpa.h"
+#include "lsst/pex/exceptions/Runtime.h"
+
+namespace py = pybind11;
+using namespace pybind11::literals;
+
+namespace lsst {
+namespace display {
+namespace ds9 {
+
+namespace {
+
+class myXPA {
+public:
+    static XPA get(bool reset=false) {
+        static myXPA *singleton = NULL;
+
+        if (reset && singleton != NULL) {
+            delete singleton;
+            singleton = NULL;
+        }
+
+        if (singleton == NULL) {
+            singleton = new myXPA("w");
+        }
+
+        return singleton->_xpa;
+    }
+private:
+    myXPA(myXPA &) = delete;
+    myXPA operator=(myXPA const &) = delete;
+
+    myXPA(char const *mode) {
+        _xpa = XPAOpen((char *)mode);
+
+        if (_xpa == NULL) {
+            throw LSST_EXCEPT(lsst::pex::exceptions::IoError, "Unable to open XPA");
+        }
+    }
+    
+    ~myXPA() {
+        XPAClose(_xpa);
+    }
+
+    static XPA _xpa;                // the real XPA connection
+};
+
+XPA myXPA::_xpa = NULL;
+
+/*
+ * A binding for XPAGet that talks to only one server, but doesn't have to talk (char **) with SWIG
+ */
+const char *
+XPAGet1(XPA xpa,
+    char *xtemplate,
+    char *paramlist,
+    char *mode)
+{
+    char *buf = NULL;           /* desired response */
+    size_t len = 0;         /* length of buf; ignored */
+    char *error = NULL;         /* returned error if any*/
+
+    if (xpa == NULL) {
+        xpa = myXPA::get();
+    }
+
+    int n = XPAGet(xpa, xtemplate, paramlist, mode,
+                   &buf, &len, NULL, &error, 1);
+
+    if (n == 0) {
+        throw LSST_EXCEPT(lsst::pex::exceptions::IoError, "XPAGet returned 0");
+    }
+    if (error != NULL) {
+        return error;
+    }
+    if (buf == NULL) {
+        throw LSST_EXCEPT(lsst::pex::exceptions::IoError, "XPAGet returned a null buffer pointer");
+    }
+
+    return(buf);
+}
+
+const char *
+XPASet1(XPA xpa,
+    char *xtemplate,
+    char *paramlist,
+    char *mode,
+    char *buf,          // desired extra data
+    int len=-1)         // length of buf (or -1 to compute automatically)
+{
+    if (len < 0) {
+        len = strlen(buf);      // length of buf
+    }
+    char *error = NULL;         // returned error if any
+
+    if (xpa == NULL) {
+        xpa = myXPA::get();
+    }
+
+    int n = XPASet(xpa, xtemplate, paramlist, mode,
+                   buf, len, NULL, &error, 1);
+
+    if (n == 0) {
+        throw LSST_EXCEPT(lsst::pex::exceptions::IoError, "XPASet returned 0");
+    }
+    if (error != NULL) {
+        return error;
+    }
+
+    return "";
+}
+
+const char *
+XPASetFd1(XPA xpa,
+    char *xtemplate,
+    char *paramlist,
+    char *mode,
+    int fd)           /* file descriptor for xpa to read */
+{
+    char *error = NULL;         /* returned error if any*/
+
+    if (xpa == NULL) {
+        xpa = myXPA::get();
+    }
+
+    int n = XPASetFd(xpa, xtemplate, paramlist, mode,
+             fd, NULL, &error, 1);
+
+    if (n == 0) {
+        throw LSST_EXCEPT(lsst::pex::exceptions::IoError, "XPASetFd returned 0");
+    }
+    if (error != NULL) {
+        return error;
+    }
+    return "";
+}
+
+void reset() {
+    myXPA::get(true);
+}
+
+}  // <anonymous>
+
+PYBIND11_PLUGIN(_xpa) {
+    py::module mod("_xpa", "Simple interface to the xpa routines used to communicate with ds9");
+
+    py::class_<xparec> cls(mod, "xparec");
+    cls.def(py::init<>());
+
+    mod.def("get", &XPAGet1, "xpa"_a, "xtemplate"_a, "paramList"_a, "mode"_a);
+    mod.def("reset", &reset);
+    mod.def("set", &XPASet1, "xpa"_a, "xtemplate"_a, "paramList"_a, "mode"_a, "buf"_a, "len"_a=-1);
+    mod.def("setFd1", &XPASetFd1, "xpa"_a, "xtemplate"_a, "paramList"_a, "mode"_a, "fd"_a);
+
+    return mod.ptr();
+}
+
+}  // ds9
+}  // display
+}  // lsst

--- a/python/lsst/display/ds9/ds9.py
+++ b/python/lsst/display/ds9/ds9.py
@@ -36,12 +36,14 @@ import re
 import sys
 import time
 
+import numpy as np
+
 import lsst.afw.display.interface as interface
 import lsst.afw.display.virtualDevice as virtualDevice
 import lsst.afw.display.ds9Regions as ds9Regions
 
 try:
-    from . import xpa
+    from . import xpa as xpa
 except ImportError as e:
     print("Cannot import xpa: %s" % (e), file=sys.stderr)
 
@@ -463,8 +465,10 @@ def _i_mtv(data, wcs, title, isMask):
     if True:
         if isMask:
             xpa_cmd = "xpaset %s fits mask" % getXpaAccessPoint()
-            if re.search(r"unsigned short|std::uint16_t", data.__str__()):
-                data |= 0x8000  # Hack. ds9 mis-handles BZERO/BSCALE in masks. This is a copy we're modifying
+            # ds9 mis-handles BZERO/BSCALE in uint16 data. The following hack works around this.
+            # This is a copy we're modifying
+            if data.getArray().dtype == np.uint16:
+                data |= 0x8000
         else:
             xpa_cmd = "xpaset %s fits" % getXpaAccessPoint()
 

--- a/ups/display_ds9.cfg
+++ b/ups/display_ds9.cfg
@@ -4,12 +4,11 @@ import lsst.sconsUtils
 
 dependencies = dict(
     required = [ "pex_exceptions", "xpa"],
-    buildRequired = ["swig"],
+    buildRequired = ["pybind11"],
 )
 
 config = lsst.sconsUtils.Configuration(
     __file__,
     libs=[],
     hasDoxygenInclude=False,
-    hasSwigFiles=True,
 )

--- a/ups/display_ds9.table
+++ b/ups/display_ds9.table
@@ -1,5 +1,6 @@
 setupRequired(afw)
 setupRequired(xpa)
 setupRequired(python_future)
+setupRequired(pybind11)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
Wrap the C interface to xpa. Note that this is a close copy of the old SWIG code. A C interface is defined in the pybind11 wrapper file. I could move the C interface to a new file but it would be a lot more work because there's no header file and I have to be careful of globals.